### PR TITLE
Newtonsoft with contract resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ services
 services
     .AddNewtonsoftJson(options =>
     {
-        options.SerializerSettings.Converters.Add(new Harvzor.Optional.NewtonsoftJson.OptionalJsonConverter());
+        options.SerializerSettings.Converters.Add(new OptionalJsonConverter());
+        options.SerializerSettings.ContractResolver = new OptionalShouldSerializeContractResolver();
     });
 ```
 

--- a/examples/Harvzor.Optional.NewtonsoftJson.JsonExample/Program.cs
+++ b/examples/Harvzor.Optional.NewtonsoftJson.JsonExample/Program.cs
@@ -5,7 +5,14 @@ using Newtonsoft.Json;
 // The JSON would normally come from some external data source:
 string json = "{\"DefinedProperty\":\"Bar\"}";
 
-Foo foo = JsonConvert.DeserializeObject<Foo>(json, new OptionalJsonConverter());
+Foo foo = JsonConvert.DeserializeObject<Foo>(json, new JsonSerializerSettings()
+{
+    Converters = new List<JsonConverter>
+    {
+        new OptionalJsonConverter(),
+    },
+    ContractResolver = new OptionalShouldSerializeContractResolver(),
+});
 
 Console.WriteLine(foo.DefinedProperty.IsDefined); // True
 Console.WriteLine(foo.UndefinedProperty.IsDefined); // False

--- a/examples/Harvzor.Optional.NewtonsoftJson.WebExample/Program.cs
+++ b/examples/Harvzor.Optional.NewtonsoftJson.WebExample/Program.cs
@@ -1,4 +1,5 @@
 using Harvzor.Optional;
+using Harvzor.Optional.NewtonsoftJson;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 
@@ -20,7 +21,8 @@ builder.Services
     // https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-7.0#configure-json-deserialization-options-for-body-binding
     .AddNewtonsoftJson(options =>
     {
-        options.SerializerSettings.Converters.Add(new Harvzor.Optional.NewtonsoftJson.OptionalJsonConverter());
+        options.SerializerSettings.Converters.Add(new OptionalJsonConverter());
+        options.SerializerSettings.ContractResolver = new OptionalShouldSerializeContractResolver();
     });
 
 var app = builder.Build();

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalJsonConverter.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalJsonConverter.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Linq;
 using Newtonsoft.Json;
-
-// Missing XML comment for publicly visible type or member
-#pragma warning disable CS1591
 
 namespace Harvzor.Optional.NewtonsoftJson;
 
 /// <summary>
 /// Register this customer Newtonsoft converter to get JSON support of <see cref="Optional{T}"/>. Docs: https://www.newtonsoft.com/json/help/html/CustomJsonConverter.htm
 /// <br/><br/>
-/// This converter ensures that the actual value is read and written correctly, but cannot effect how / if the property
+/// This converter ensures that the actual value is read and written correctly, but cannot affect how / if the property
 /// name is serialized (the <see cref="OptionalShouldSerializeContractResolver"/> can do that).
 /// </summary>
 /// <remarks>
@@ -19,6 +15,7 @@ namespace Harvzor.Optional.NewtonsoftJson;
 /// </remarks>
 public class OptionalJsonConverter : JsonConverter
 {
+    /// <inheritdoc />
     public override bool CanConvert(Type objectType)
     {
         return IsOptional(objectType);
@@ -29,6 +26,7 @@ public class OptionalJsonConverter : JsonConverter
         return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Optional<>);
     }
 
+    /// <inheritdoc />
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
     {
         var optionalInstance = Activator.CreateInstance(objectType);
@@ -39,6 +37,7 @@ public class OptionalJsonConverter : JsonConverter
         return optionalInstance;
     }
 
+    /// <inheritdoc />
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
         var optionalType = value.GetType();

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalJsonConverter.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalJsonConverter.cs
@@ -9,6 +9,9 @@ namespace Harvzor.Optional.NewtonsoftJson;
 
 /// <summary>
 /// Register this customer Newtonsoft converter to get JSON support of <see cref="Optional{T}"/>. Docs: https://www.newtonsoft.com/json/help/html/CustomJsonConverter.htm
+/// <br/><br/>
+/// This converter ensures that the actual value is read and written correctly, but cannot effect how / if the property
+/// name is serialized (the <see cref="OptionalShouldSerializeContractResolver"/> can do that).
 /// </summary>
 /// <remarks>
 /// Dev note: It's generally better to use `JsonConverter&lt;T&gt;` because that only has to convert a specific property,

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
@@ -5,6 +5,9 @@ using Newtonsoft.Json.Serialization;
 
 namespace Harvzor.Optional.NewtonsoftJson;
 
+/// <summary>
+/// https://github.com/JamesNK/Newtonsoft.Json/issues/1859#issuecomment-463061596
+/// </summary>
 public class OptionalShouldSerializeContractResolver : DefaultContractResolver
 {
     protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
@@ -18,6 +21,7 @@ public class OptionalShouldSerializeContractResolver : DefaultContractResolver
                 {
                     IMember? propertyOrField = instance.GetType().GetPropertyOrField(property.UnderlyingName);
 
+                    // TODO: improve exception
                     if (propertyOrField == null)
                         throw new Exception("Member should surely be found on class?");
 

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json.Serialization;
 namespace Harvzor.Optional.NewtonsoftJson;
 
 /// <summary>
+/// Ensures that only properties with defined values are printed in the output JSON when serializing. Without this, the
+/// property name will still be serialized, but without a value.
 /// https://github.com/JamesNK/Newtonsoft.Json/issues/1859#issuecomment-463061596
 /// </summary>
 public class OptionalShouldSerializeContractResolver : DefaultContractResolver

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Harvzor.Optional.NewtonsoftJson;
+
+public class OptionalShouldSerializeContractResolver : DefaultContractResolver
+{
+    protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+    {
+        JsonProperty property = base.CreateProperty(member, memberSerialization);
+    
+        if (property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Optional<>))
+        {
+            property.ShouldSerialize =
+                instance =>
+                {
+                    IMember? propertyOrField = instance.GetType().GetPropertyOrField(property.UnderlyingName);
+
+                    if (propertyOrField == null)
+                        throw new Exception("Member should surely be found on class?");
+
+                    IOptional optional = (IOptional)propertyOrField.GetValue(instance);
+                    return optional.IsDefined;
+                };
+        }
+    
+        return property;
+    }
+}

--- a/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
+++ b/src/Harvzor.Optional.NewtonsoftJson/OptionalShouldSerializeContractResolver.cs
@@ -12,6 +12,7 @@ namespace Harvzor.Optional.NewtonsoftJson;
 /// </summary>
 public class OptionalShouldSerializeContractResolver : DefaultContractResolver
 {
+    /// <inheritdoc />
     protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
     {
         JsonProperty property = base.CreateProperty(member, memberSerialization);
@@ -21,11 +22,7 @@ public class OptionalShouldSerializeContractResolver : DefaultContractResolver
             property.ShouldSerialize =
                 instance =>
                 {
-                    IMember? propertyOrField = instance.GetType().GetPropertyOrField(property.UnderlyingName);
-
-                    // TODO: improve exception
-                    if (propertyOrField == null)
-                        throw new Exception("Member should surely be found on class?");
+                    IMember propertyOrField = instance.GetType().GetPropertyOrField(property.UnderlyingName)!;
 
                     IOptional optional = (IOptional)propertyOrField.GetValue(instance);
                     return optional.IsDefined;

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -26,7 +26,7 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
             // Formatting = Formatting.Indented,
             Converters = new List<Newtonsoft.Json.JsonConverter>
             {
-                new OptionalJsonConverter()
+                new OptionalJsonConverter(),
             },
             ContractResolver = new OptionalShouldSerializeContractResolver(),
         })!;

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -22,6 +22,8 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
     {
         return JsonConvert.SerializeObject(obj, new JsonSerializerSettings
         {
+            // TODO: setting to indented doesn't change the output as the output has been overwritten...
+            // Formatting = Formatting.Indented,
             Converters = new List<Newtonsoft.Json.JsonConverter>
             {
                 new OptionalJsonConverter()

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -20,14 +20,13 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
 
     protected override string Serialize(object obj)
     {
-        return JsonConvert.SerializeObject(obj, new JsonSerializerSettings()
+        return JsonConvert.SerializeObject(obj, new JsonSerializerSettings
         {
-            // TODO: setting to indented doesn't change the output as the output has been overwritten...
-            // Formatting = Formatting.Indented,
             Converters = new List<Newtonsoft.Json.JsonConverter>
             {
-                new OptionalJsonConverter(),
+                new OptionalJsonConverter()
             },
+            ContractResolver = new OptionalShouldSerializeContractResolver(),
         })!;
     }
     

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -20,7 +20,7 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
 
     protected override string Serialize(object obj)
     {
-        return JsonConvert.SerializeObject(obj, new JsonSerializerSettings
+        return JsonConvert.SerializeObject(obj, new JsonSerializerSettings()
         {
             // TODO: setting to indented doesn't change the output as the output has been overwritten...
             // Formatting = Formatting.Indented,

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -15,6 +15,8 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
             {
                 new OptionalJsonConverter(),
             },
+            // Isn't needed as the contract resolver only effects writing:
+            // ContractResolver = new OptionalShouldSerializeContractResolver(),
         })!;
     }
 

--- a/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
+++ b/tests/Harvzor.Optional.NewtonsoftJson.Tests/OptionalJsonConverterTests.cs
@@ -1,5 +1,7 @@
 using Harvzor.Optional.JsonConverter.BaseTests;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Harvzor.Optional.NewtonsoftJson.Tests;
 
@@ -87,7 +89,7 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
     }
     
     [Fact]
-    [Trait("Category","Works With Other Custom Converter")]
+    [Trait("Category","Integrates With Other Converters / Contract Resolvers")]
     public void WriteJson_ShouldWriteValue_WhenOptionalPropertyInObjectIsDefinedAndThereIsAnotherConverter()
     {
         // Arrange
@@ -106,12 +108,74 @@ public class OptionalJsonConverterTests : OptionalJsonConverterBaseTests
 
         json.ShouldBe("{\"OptionalProperty\":\"some value\",\"VersionProperty\":\"1.2.3\"}");
     }
-    
+
     private class ClassWithOptionalPropertyAndVersionConverter
     {
         public Optional<string> OptionalProperty { get; set; }
         
         [JsonConverter(typeof(VersionConverter))]
         public Version VersionProperty { get; set; }
+    }
+    
+    [Fact]
+    [Trait("Category","Integrates With Other Converters / Contract Resolvers")]
+    public void WriteJson_ShouldWriteValue_WhenMultipleContractResolversAreUsed()
+    {
+        // Arrange
+
+        ClassWithOptionalPropertyAndDateTime classWithOptionalPropertyAndDateTime = new ClassWithOptionalPropertyAndDateTime
+        {
+            OptionalProperty = new DateTime(2023, 01, 01),
+            OptionalPropertyTwo = new Optional<DateTime>(),
+            DateTime = new DateTime(2022, 01, 01),
+        };
+
+        // Act
+        
+        string json = JsonConvert.SerializeObject(classWithOptionalPropertyAndDateTime, new JsonSerializerSettings()
+        {
+            Converters = new List<Newtonsoft.Json.JsonConverter>
+            {
+                new OptionalJsonConverter(),
+            },
+            ContractResolver = new DateTimeMixedWithOptionalContractResolver(),
+        });
+
+        // Assert
+
+        json.ShouldBe("{\"OptionalProperty\":new Date(1672527600000),\"DateTime\":new Date(1640991600000)}");
+    }
+    
+    private class ClassWithOptionalPropertyAndDateTime
+    {
+        public Optional<DateTime> OptionalProperty { get; set; }
+        
+        public Optional<DateTime> OptionalPropertyTwo { get; set; }
+        
+        public DateTime DateTime { get; set; }
+    }
+    
+    /// <summary>
+    /// https://www.newtonsoft.com/json/help/html/contractresolver.htm
+    /// </summary>
+    /// <remarks>
+    /// This method (of inheriting from other resolvers) doesn't allow you to use a built in contract resolvers, maybe
+    /// there's a better way of compositing resolvers here:
+    /// https://stackoverflow.com/questions/39612636/add-multiple-contract-resolver-in-newtonsoft-json
+    /// </remarks>
+    private class DateTimeMixedWithOptionalContractResolver : OptionalShouldSerializeContractResolver
+    {
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            JsonContract contract = base.CreateContract(objectType);
+
+            // this will only be called once and then cached
+            if (objectType == typeof(DateTime) || objectType == typeof(DateTimeOffset))
+            {
+                contract.Converter = new JavaScriptDateTimeConverter();
+            }
+
+            return contract;
+        }
     }
 }


### PR DESCRIPTION
The problem with only using the `OptionalJsonConverter` is that it can't choose when a property is serialized unless you convert full objects which have Optional<T> properties inside of them.

However, the problem with serializing full objects is then you need to take care of ensuring that the `JsonPropertyAttribute` and `JsonIgnoreAttribute` still work, as well as many other edge cases (such as how indentation should work).

A contract resolver lets you choose which properties are even attempted to be serialized.